### PR TITLE
SpotifyGPX 2.0.0 List Indexing Method

### DIFF
--- a/Options.cs
+++ b/Options.cs
@@ -1,15 +1,26 @@
 ﻿// SpotifyGPX by Simon Field
 
 using System;
+using SpotifyGPX.Parsing;
 
-namespace SpotifyGPX.Dependencies
+namespace SpotifyGPX.Options
 {
     public class SongResponse
     {
+        // Output Time Formats
+        public static readonly string gpxPointDescription = "yyyy-MM-dd HH:mm:ssZ"; // time format used in the <desc> field a GPX song point (your choice)
+        public static readonly string gpxPointTimeOut = "yyyy-MM-ddTHH:mm:ss.fffZ"; // time format used as the <time> parameter for a GPX song point (ISO 8601)
+
+        // Input Time Formats
+        public static readonly string gpxPointTimeInp = "yyyy-MM-ddTHH:mm:ss.fffzzz"; // time format used to interpret GPX track <time> tags
+        public static readonly string spotifyJsonTime = "yyyy-MM-dd HH:mm"; // time format of a song entry in Spotify JSON
+
         public static string Identifier(SpotifyEntry song, string type)
         {
+            // Function defining the preferred return strings of GPX point metadata
+
             // Song Statistics
-            string time_end = song.endTime; // This field is a timestamp indicating when the track stopped playing in UTC (Coordinated Universal Time). The order is year, month and day followed by a timestamp in military time
+            string time_end = Spotify.JsonTimeZone(song.endTime).ToString(gpxPointDescription); // This field is a timestamp indicating when the track stopped playing in UTC (Coordinated Universal Time). The order is year, month and day followed by a timestamp in military time
             string milliseconds_played = song.msPlayed; // This field is the number of milliseconds the stream was played.
 
             // Track Metadata
@@ -21,7 +32,7 @@ namespace SpotifyGPX.Dependencies
                 // ===================== \\
                 // GPX POINT DESCRIPTION \\
                 // ===================== \\
-                return $"{track_name} by {artist}\nEnded at {time_end}";
+                return $"Ended at {time_end}";
             }
             else
             {

--- a/Program.cs
+++ b/Program.cs
@@ -104,10 +104,11 @@ class Program
 
         // Correlate Spotify entries with the nearest GPX points
         List<(SpotifyEntry, GPXPoint)> correlatedEntries = new();
-        foreach (var spotifyEntry in spotifyEntriesInRange)
+        foreach (SpotifyEntry spotifyEntry in spotifyEntriesInRange)
         {
             GPXPoint nearestPoint = gpxPoints.OrderBy(point => Math.Abs((point.Time - Spotify.JsonTimeZone(spotifyEntry.endTime)).TotalSeconds)).First();
             correlatedEntries.Add((spotifyEntry, nearestPoint));
+            Console.WriteLine($"[INFO] JSON Entry Identified: '{SongResponse.Identifier(spotifyEntry, "name")}'");
         }
 
         // Display the correlated entries
@@ -118,92 +119,13 @@ class Program
             Console.WriteLine();
         }
 
-        // Create song variable to hold the previous song
-        SpotifyEntry? currentSong = null;
-
-        // Create a variable to hold the nearest calculated song
-        SpotifyEntry? nearestSong = null;
-
-        // Create a list of each task created
-        List<Task> createdTasks = new();
-
-        // Create a list of completed tasks, containing their resulting songs
-        List<SpotifyEntry> completedTasks = new();
-
-        // Create a list of songs and points to be used for the final GPX
-        List<(SpotifyEntry, GPXPoint)> finalPoints = new();
-
-        List<SpotifyEntry> relevantEntries = new();
-
-        foreach (SpotifyEntry entry in spotifyEntries)
-        {
-            DateTimeOffset songEndTimestamp = Spotify.JsonTimeZone(entry.endTime);
-
-            if (songEndTimestamp > gpxStartTime)
-            {
-                // ensures the song ended after the first GPX point was taken
-                if (songEndTimestamp < gpxEndTime)
-                {
-                    // ensures the song ended before the last GPX point was taken
-                    relevantEntries.Add(entry);
-                }
-                else
-                {
-                    // spotifyDump scan passed relevant entries, exit
-                    break;
-                }
-            }
-        }
-
-        // Features:
-        // DONE 1. loop through GPX file, adding all points to List<gpxPoints>
-        // DONE 2. Store gpxPoint startPoint, endPoint in dedicated gpxPoint objects based on first and last indexes of List<gpxPoints>
-        // DONE 3. loop through spotify entries, adding each to List<SpotifyEntry>
-        // 4. once the nearest SpotifyEntry to GPX startPoint is found, save the index of the first SpotifyEntry
-        // 5. continue through the list of SpotifyEntry objects until the nearest to GPX endPoint is found, save that index
-        // 6. create a list<SpotifyEntry> of each entry correlated between the start and end GPX point
-        // 7. loop through list<SpotifyEntry>, finding the nearest GPX point to it
-        // 8. create a tuple of SpotifyEntry and gpxPoint objects nearest each other
-
         // OTHER FEATURES TO ADD:
         // - JSON exporting (export the relevant part of the Spotify JSON to a new file for future reference)
-        // - if this doesn't match last one, warn that a song was missed, and print the entry
-
-        // Iterate through GPX points and find the nearest song
-        foreach (GPXPoint gpxPoint in gpxPoints)
-        {
-            // Find the nearest song based on timestamp
-            Task<SpotifyEntry> task = Task.Run(() => Spotify.FindNearestSong(spotifyEntries, gpxPoint.Time));
-
-            // Add the task to the created tasks list
-            createdTasks.Add(task);
-
-            // Add the task's song to the completed tasks list once it is finished calculating
-            completedTasks.Add(await task);
-
-            // Set the nearest song calculated to the identified result
-            nearestSong = task.Result;
-
-            // Ensures the identified song does not contain duplicate entries
-            if (nearestSong != null && !Spotify.IsSameSong(nearestSong, currentSong))
-            {
-                // If this song is different to the prior:
-                
-                Console.WriteLine($"[INFO] JSON entry identified: '{SongResponse.Identifier(nearestSong, "name")}'");
-
-                // Add the calculated nearest song and its point to the final list
-                finalPoints.Add((nearestSong, gpxPoint));
-
-                // Update the current song to avoid duplicates
-                currentSong = nearestSong;
-            }
-        }
-
-        // Wait for all nearest songs to be calculated and identified
-        Task.WaitAll(createdTasks.ToArray());
-
+        // - Playlist exporting (export a GPX of song points to a m3u or some such file)
+        // - Spotify linkage (export a series of spotify URI so these can be reimported
+        
         // Create a GPX document based on the list of points
-        XmlDocument document = GPX.CreateGPXFile(finalPoints, Path.GetFileName(gpxFilePath));
+        XmlDocument document = GPX.CreateGPXFile(correlatedEntries, Path.GetFileName(gpxFilePath));
 
         // Save the GPX to the file
         document.Save(finalFilePath);
@@ -218,55 +140,6 @@ namespace SpotifyGPX.Parsing
 {
     public static class Spotify
     {
-        public static SpotifyEntry FindNearestSong(List<SpotifyEntry> spotifyData, DateTimeOffset trkptTimestamp)
-        {
-            // Initialize variables to keep track of the nearest song
-            SpotifyEntry? nearestSong = null;
-
-            // Initialize variable to hold max time difference, starting at infinity working downward
-            double nearestTimeDifference = double.MaxValue;
-
-            foreach (SpotifyEntry entry in spotifyData)
-            {
-                // For every entry in the Spotify JSON:
-
-                // Parse the date and time when the song ended
-                DateTimeOffset songEndTimestamp = Spotify.JsonTimeZone(entry.endTime);
-
-                // Calculate the time difference in seconds between the GPX point timestamp and the song end timestamp
-                double timeDifferenceSec = Math.Abs((songEndTimestamp - trkptTimestamp).TotalSeconds);
-
-                // Check if this song is closer than the previous song to the GPX point
-                if (timeDifferenceSec < nearestTimeDifference)
-                {
-                    // If it is closer, continue:
-
-                    if (trkptTimestamp <= songEndTimestamp)
-                    {
-                        // The GPX point was taken before the end of the song, it is valid:
-
-                        nearestSong = entry;
-                        nearestTimeDifference = timeDifferenceSec;
-
-                    }
-                }
-                else
-                {
-                    // If this song is farther than the previous (reader has passed relevant songs), skip it:
-                    break;
-                }
-            }
-
-            // Return the calculated nearest song of the point
-            return nearestSong;
-        }
-
-        public static bool IsSameSong(SpotifyEntry song1, SpotifyEntry song2)
-        {
-            // Check if two Spotify entries represent the same song
-            return song1 != null && song2 != null && song1.trackName == song2.trackName;
-        }
-
         public static DateTimeOffset JsonTimeZone(string inputTime)
         {
             DateTimeOffset spotifyTimestamp = DateTimeOffset.ParseExact(inputTime, SongResponse.spotifyJsonTime, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);

--- a/README.md
+++ b/README.md
@@ -41,5 +41,8 @@ Create GPX waypoints based on timed GPX tracks and Spotify listening history. Gr
  1. Use an app such as [GPSLogger](https://github.com/mendhak/gpslogger) to track your position
  2. Ensure the frequency of points is high, since a song is tied to each point
 
+## Future Additions
 
- 
+ - JSON exporting (export the relevant part of the Spotify JSON to a new file for future reference)
+ - Playlist exporting (export a GPX of song points to a m3u or some such file)
+ - Spotify linkage (export a series of spotify URI so these can be reimported


### PR DESCRIPTION
Accuracy and point/song inclusion has been improved significantly. From now on, all songs within the time period of the GPX file will be included, and song placement overlap will occur with infrequent logging/song match conflict, but all songs are still included nonetheless.