### PR TITLE
KML linestring can include coordinates not relating to dupe.

### DIFF
--- a/Options.cs
+++ b/Options.cs
@@ -108,7 +108,7 @@ namespace SpotifyGPX
 
     public struct GPXPoint
     {
-        public bool Predicted { get; set; }
+        public bool? Predicted { get; set; }
         public double Latitude { get; set; }
         public double Longitude { get; set; }
         public DateTimeOffset Time { get; set; }


### PR DESCRIPTION
KML can now contain LineString exceeding dupe range without being considered.